### PR TITLE
More documentation and traits for `Locale`

### DIFF
--- a/generate-api/src/generator.rs
+++ b/generate-api/src/generator.rs
@@ -496,10 +496,12 @@ impl CodeGenerator {
             /// Most locale names follow the syntax `language[_territory][@modifier]`.
             /// The `@` is replaced with `_` in the `enum` variant names.
             ///
+            /// The default locale is `POSIX`.
+            ///
             /// License note: The Free Software Foundation does not claim any copyright interest in the locale
             /// data of the GNU C Library; they believe it is not copyrightable.
             #[allow(non_camel_case_types,dead_code)]
-            #[derive(Debug, Copy, Clone, PartialEq)]
+            #[derive(Debug, Copy, Clone, Default, PartialEq)]
             pub enum Locale {{
             "#,
         )?;
@@ -526,16 +528,11 @@ impl CodeGenerator {
                 },
                 _ => "".to_string(),
             };
-            write!(
-                f,
-                r#"
-                /// `{lang}`: {desc}
-                {norm},
-                "#,
-                lang = lang,
-                desc = desc,
-                norm = norm,
-            )?;
+            write!(f, "\n/// `{}`: {}\n", lang, desc)?;
+            if lang == &"POSIX" {
+                writeln!(f, "\n#[default]\n")?;
+            }
+            writeln!(f, "\n{},\n", norm)?;
         }
 
         f.dedent(1);

--- a/generate-api/src/generator.rs
+++ b/generate-api/src/generator.rs
@@ -499,13 +499,34 @@ impl CodeGenerator {
         f.indent(1);
 
         for (lang, norm) in self.normalized_langs.iter() {
+            let desc = match self
+                .by_language
+                .get(lang)
+                .and_then(|l| l.get("LC_IDENTIFICATION"))
+            {
+                Some(Category::Fields(fields)) => match fields.get("TITLE") {
+                    Some(Value::Literal(title)) => {
+                        let mut title = title.clone();
+                        if !title.ends_with('.') {
+                            title.push('.');
+                        }
+                        title
+                    }
+                    _ => match lang == "POSIX" {
+                        true => "POSIX Standard Locale.".to_string(),
+                        false => "".to_string(),
+                    },
+                },
+                _ => "".to_string(),
+            };
             write!(
                 f,
                 r#"
-                /// {lang}
+                /// `{lang}`: {desc}
                 {norm},
                 "#,
                 lang = lang,
+                desc = desc,
                 norm = norm,
             )?;
         }

--- a/generate-api/src/generator.rs
+++ b/generate-api/src/generator.rs
@@ -501,7 +501,7 @@ impl CodeGenerator {
             /// License note: The Free Software Foundation does not claim any copyright interest in the locale
             /// data of the GNU C Library; they believe it is not copyrightable.
             #[allow(non_camel_case_types,dead_code)]
-            #[derive(Copy, Clone, Default, PartialEq)]
+            #[derive(Copy, Clone, Default, PartialEq, Eq, Hash)]
             pub enum Locale {{
             "#,
         )?;

--- a/generate-api/src/generator.rs
+++ b/generate-api/src/generator.rs
@@ -501,7 +501,7 @@ impl CodeGenerator {
             /// License note: The Free Software Foundation does not claim any copyright interest in the locale
             /// data of the GNU C Library; they believe it is not copyrightable.
             #[allow(non_camel_case_types,dead_code)]
-            #[derive(Debug, Copy, Clone, Default, PartialEq)]
+            #[derive(Copy, Clone, Default, PartialEq)]
             pub enum Locale {{
             "#,
         )?;
@@ -539,6 +539,38 @@ impl CodeGenerator {
         write!(
             f,
             r#"
+            }}
+
+            impl core::fmt::Display for Locale {{
+                fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {{
+                    f.write_str(match self {{
+            "#,
+        )?;
+        f.indent(3);
+
+        for (lang, norm) in self.normalized_langs.iter() {
+            write!(
+                f,
+                r#"
+                Locale::{norm} => {lang:?},
+                "#,
+                lang = lang,
+                norm = norm,
+            )?;
+        }
+
+        f.dedent(3);
+        write!(
+            f,
+            r#"
+                    }})
+                }}
+            }}
+
+            impl core::fmt::Debug for Locale {{
+                fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {{
+                    core::fmt::Display::fmt(self, f)
+                }}
             }}
 
             impl core::str::FromStr for Locale {{

--- a/generate-api/src/generator.rs
+++ b/generate-api/src/generator.rs
@@ -491,6 +491,13 @@ impl CodeGenerator {
             f,
             r#"
 
+            /// Locales matching the locales in `glibc`.
+            ///
+            /// Most locale names follow the syntax `language[_territory][@modifier]`.
+            /// The `@` is replaced with `_` in the `enum` variant names.
+            ///
+            /// License note: The Free Software Foundation does not claim any copyright interest in the locale
+            /// data of the GNU C Library; they believe it is not copyrightable.
             #[allow(non_camel_case_types,dead_code)]
             #[derive(Debug, Copy, Clone, PartialEq)]
             pub enum Locale {{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c187a8d88ba7dce6ffc967f9a0aaf66a7ac24aaff98be85ba6f7888931c4e305
-size 2446616
+oid sha256:e06dc42faeb0377d6a129a7935399539154746fe9b24202a99fe7d828e96dbb5
+size 2473422


### PR DESCRIPTION
For chrono we re-export the `Locale` type from `pure-rust-locales`, and are going to include in in the documentation on docs.rs with the next release (still behind the `unstable-locales` feature however).

It would be nice if the enum would have more documentation for the variants and itself.

I also added the `Default`, `Eq` and `Hash` traits, and made `Display` en `Debug` implementations match the `TryFrom<&str>` implementation.