### PR TITLE
Manually implement `Default`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,3 +23,17 @@ jobs:
       - run: cargo fmt -p generate-api --check
       - run: cargo clippy
       - run: cargo clippy -p generate-api
+
+  rust_versions:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        rust_version: ["beta", "nightly", "1.56"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 keywords = ["locale", "libc", "i18n", "internationalisation", "no_std"]
 edition = "2018"
 include = ["src/**/*.rs", "tests/**/*.rs", "README.md", "LICENSE.Apache-2.0", "LICENSE.MIT"]
+rust-version = "1.56.0"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pure-rust-locales"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Cecile Tonglet <cecile.tonglet@cecton.com>"]
 description = "Pure Rust locales imported directly from the GNU C Library. `LC_COLLATE` and `LC_CTYPE` are not yet supported."
 license = "MIT OR Apache-2.0"

--- a/generate-api/src/generator.rs
+++ b/generate-api/src/generator.rs
@@ -477,6 +477,17 @@ impl CodeGenerator {
 
         self.generate_variants(f)?;
 
+        write!(
+            f,
+            r#"
+
+            impl Default for Locale {{
+                fn default() -> Self {{
+                    Locale::POSIX
+                }}
+            }}
+            "#,
+        )?;
         Ok(())
     }
 
@@ -495,7 +506,7 @@ impl CodeGenerator {
             /// License note: The Free Software Foundation does not claim any copyright interest in the locale
             /// data of the GNU C Library; they believe it is not copyrightable.
             #[allow(non_camel_case_types,dead_code)]
-            #[derive(Copy, Clone, Default, PartialEq, Eq, Hash)]
+            #[derive(Copy, Clone, PartialEq, Eq, Hash)]
             pub enum Locale {{
             "#,
         )?;
@@ -523,9 +534,6 @@ impl CodeGenerator {
                 _ => "".to_string(),
             };
             write!(f, "\n/// `{}`: {}\n", lang, desc)?;
-            if lang == "POSIX" {
-                writeln!(f, "\n#[default]\n")?;
-            }
             writeln!(f, "\n{},\n", norm)?;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55115,10 +55115,9 @@ pub mod zu_ZA {
 /// License note: The Free Software Foundation does not claim any copyright interest in the locale
 /// data of the GNU C Library; they believe it is not copyrightable.
 #[allow(non_camel_case_types,dead_code)]
-#[derive(Copy, Clone, Default, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Locale {
     /// `POSIX`: POSIX Standard Locale.
-    #[default]
     POSIX,
     /// `aa_DJ`: Afar language locale for Djibouti (Cadu/Laaqo Dialects).
     aa_DJ,
@@ -56837,4 +56836,10 @@ macro_rules! locale_match {
             $crate::Locale::zu_ZA => $crate::zu_ZA::$($item)::+,
         }
     }}
+}
+
+impl Default for Locale {
+    fn default() -> Self {
+        Locale::POSIX
+    }
 }


### PR DESCRIPTION
I broke chrono's MSRV with the `unstable-locales` feature in #8.

```
error[E0658]: deriving `Default` on enums is experimental
     --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/pure-rust-locales-0.8.0/src/lib.rs:55118:23
      |
55118 | #[derive(Copy, Clone, Default, PartialEq, Eq, Hash)]
      |                       ^^^^^^^
      |
      = note: see issue #86985 <https://github.com/rust-lang/rust/issues/86985> for more information
      = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This fixes the build for rust 1.61 and adds a CI check for the generated code on rust nightly, beta and 1.61.0.

Can we release this as 0.8.1 to make the CI for chrono green again?